### PR TITLE
v1 and v2

### DIFF
--- a/catamaran-btc/Clarinet.toml
+++ b/catamaran-btc/Clarinet.toml
@@ -19,8 +19,14 @@ contract_id = 'SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin'
 
 [[project.requirements]]
 contract_id = 'SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token'
+
 [contracts.btc-stx-swap]
 path = 'contracts/btc-stx-swap.clar'
+clarity_version = 2
+epoch = 2.5
+
+[contracts.btc-stx-option]
+path = 'contracts/btc-stx-option.clar'
 clarity_version = 2
 epoch = 2.5
 
@@ -31,6 +37,11 @@ epoch = 2.5
 
 [contracts.fees]
 path = 'contracts/fees.clar'
+clarity_version = 2
+epoch = 2.5
+
+[contracts.zero]
+path = 'contracts/zero.clar'
 clarity_version = 2
 epoch = 2.5
 

--- a/catamaran-btc/contracts/fees.clar
+++ b/catamaran-btc/contracts/fees.clar
@@ -7,10 +7,10 @@
 
 (define-private (jump-fee (ustx uint))
   (if (> ustx u37500000000) ;; $75k+ (Whales)
-    (/ ustx u133)           ;; 0.75% fee
+    (/ ustx u200)           ;; 0.5% fee
     (if (> ustx u12500000000) ;; $25k-$75k
-      (/ ustx u80)            ;; 1.25% fee
-      (/ ustx u40))))         ;; $0-$25k: 2.5% fee
+      (/ ustx u133)            ;; 0.75% fee
+      (/ ustx u100))))         ;; $0-$25k: 1% fee
 
 ;; Hold fees for the given amount in escrow.
 (define-public (hold-fees (ustx uint))


### PR DESCRIPTION
btc-stx-swap.clar: v1 - 2 minor changes to remediations

btc-stx-option: v2 - ownership is tracked via stx-call nft and can be transferred and thus sold!