### PR TITLE
private swaps and fix for re-take-ask

### DIFF
--- a/catamaran-btc/contracts/btc-stx-swap.clar
+++ b/catamaran-btc/contracts/btc-stx-swap.clar
@@ -29,6 +29,10 @@
 (define-constant cooldown u6)
 (define-constant penalty-rate u3)
 
+(define-public (get-burn-block) 
+  (ok burn-block-height)
+)
+
 (define-private (calculate-penalty (amount uint))
   (/ (* amount penalty-rate) u100))
 

--- a/catamaran-btc/contracts/command-lines.clar
+++ b/catamaran-btc/contracts/command-lines.clar
@@ -1,3 +1,6 @@
+;; happy path, collat and make ask, take ask and simulate swap: good
+;; attempting to simulate swap on expired height erroring 22 correctly
+;; taking ask twice in a expired swap: 
 (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.btc-stx-swap-simulate 
   collateralize-and-make-ask 
   u30000000000 
@@ -5,19 +8,32 @@
   u50000000 
   none)
 
+(contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.btc-stx-swap-simulate 
+  get-burn-block)
+
 (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc 
   mint-to  
   u100000000
   'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)
+(contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.sbtc 
+  mint-to  
+  u100000000
+  'ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG)
+  
 
 ::set_tx_sender ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+::set_tx_sender ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
 ::get_assets_maps
-::advance_chain_tip 7
+::advance_chain_tip 3 7
 ::advance_chain_tip 100
 ::set_tx_sender ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
 
 (contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.btc-stx-swap-simulate 
   take-ask
+  u0)
+
+(contract-call? 'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.btc-stx-swap-simulate
+  get-swap
   u0)
 
 ;; trying to change the ask after it's taken


### PR DESCRIPTION
a private swap is when stx-receiver is designated at creation before take-bid or take-ask

take-bid:
in private swap, stx sender can change the stx-receiver (none branch of expiration-height)

take-ask:
never reserved swaps (none branch of expired-height) error out if tx-sender is not the designated stx-receiver